### PR TITLE
[BUGFIX] Assign array key to doctrine event listener

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -14,6 +14,6 @@ TYPO3:
     persistence:
       doctrine:
         eventListeners:
-          -
+          'Gedmo\Translatable\TranslatableListener':
             events: ['postLoad', 'postPersist', 'preFlush', 'onFlush', 'loadClassMetadata']
             listener: 'Gedmo\Translatable\TranslatableListener'


### PR DESCRIPTION
Because of the unkeyed array (using "-"), Flow will merge the array of
setting TYPO3.Flow.persistence.doctrine.eventListeners with another
unkeyed array from another package which will cause issue that the last
package's setting will override the previous ones.

fixes: #1 
