### PR TITLE
BUGFIX: translation repository behavior due to Flow managed entity cl…

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,10 +7,6 @@ Sandstorm:
     persistDefaultLocaleTranslation: false
 Neos:
   Flow:
-    object:
-      includeClasses:
-        gedmo.doctrineextensions:
-          - 'Gedmo\\Translatable\\Entity'
     persistence:
       doctrine:
         eventListeners:


### PR DESCRIPTION
…asses

Previously, the Translation entity got added to the Flow object includeClasses setting to fix a problem in the core. However, the translation repository (findOneBy query) of the Gedmo extension creates wrong queries when managed by the Flow framework.

To make independent doctrine entities work with Flow again, a fix to the Neos.Flow package might be added (PR: https://github.com/neos/flow-development-collection/pull/1955).